### PR TITLE
Mailbox Subscriptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,16 @@
 "use strict";
 
 const apn = require("apn");
+const crypto = require("crypto");
 const redis = require("redis");
 const Promise = require("bluebird");
 
 Promise.promisifyAll(redis.RedisClient.prototype);
 
-const Controller = require("./lib/controller")({Notification: apn.Notification});
+const Controller = require("./lib/controller")({
+  Notification: apn.Notification,
+  md5: (data) => crypto.createHash('md5').update(data).digest("hex"),
+});
 const Server = require("./lib/server");
 const Socket = require("./lib/socket");
 

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -5,6 +5,7 @@ const Promise = require("bluebird");
 module.exports = function(dependencies) {
   
   const Notification = dependencies.Notification;
+  const md5          = dependencies.md5
 
   function Controller(props) {
     this.apn    = props.apn;
@@ -16,6 +17,7 @@ module.exports = function(dependencies) {
     const prefix = this.prefix;
 
     this.redis.sadd(`${prefix}${username}:device`, `${deviceToken}:${accountId}`);
+    this.redis.del(`${prefix}${username}:${deviceToken}:${accountId}:subscriptions`);
   }
 
   Controller.prototype.notify = function notify(username, mailbox) {
@@ -33,6 +35,12 @@ module.exports = function(dependencies) {
             .each( failed => this.redis.sremAsync(usernameKey, `${failed.device}:${accountId}`))
         }))
     );
+  }
+
+  Controller.prototype.subscribe = function subscribe(username, accountId, deviceToken, mailbox) {
+    const prefix = this.prefix;
+
+    this.redis.sadd(`${prefix}${username}:${deviceToken}:${accountId}:subscriptions`, md5(mailbox));
   }
 
   return Controller;

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -22,18 +22,31 @@ module.exports = function(dependencies) {
 
   Controller.prototype.notify = function notify(username, mailbox) {
     const prefix = this.prefix;
-    const usernameKey = `${prefix}${username}:device`
+    const usernameKey = `${prefix}${username}`
+    const mailboxHash = md5(mailbox);
 
-    return this.redis.smembersAsync(usernameKey)
+    return this.redis.smembersAsync(`${usernameKey}:device`)
       .then( deviceAccounts => Promise.all(
         deviceAccounts.map( deviceAccount => {
-          const [device, accountId] = deviceAccount.split(":", 2);
-          const notification = new Notification({aps: {"account-id": accountId}});
+          return this.redis.sismemberAsync(`${usernameKey}:${deviceAccount}:subscriptions`, mailboxHash)
+            .then( shouldSend => {
+              if (!shouldSend) {
+                return null;
+              }
+              const [device, accountId] = deviceAccount.split(":", 2);
+              const notification = new Notification({aps: {"account-id": accountId, m: [mailboxHash]}});
 
-          return Promise.resolve(this.apn.send(notification, device))
-            .then( ( { failed } ) => failed)
-            .each( failed => this.redis.sremAsync(usernameKey, `${failed.device}:${accountId}`))
-        }))
+              return Promise.resolve(this.apn.send(notification, device))
+                .then( ( { failed } ) => failed)
+                .filter( ( { response } ) => response.reason == "Unregistered" )
+                .each( failed => Promise.all([
+                  this.redis.sremAsync(`${usernameKey}:device`, `${failed.device}:${accountId}`),
+                  this.redis.delAsync(`${usernameKey}:${deviceAccount}:subscriptions`),
+                ])
+              );
+            });
+        })
+      )
     );
   }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -35,6 +35,9 @@ Server.prototype.receive = function receive(data) {
     case 3:
       this.controller.notify(message.d1, message.d2);
       break;
+
+    case 4:
+      this.controller.subscribe(message.d1, message.d2, message.d3, message.d4);
   }
 }
 

--- a/test/controller.js
+++ b/test/controller.js
@@ -14,6 +14,7 @@ describe("Controller", function() {
       prefix: "test_pn_prefix:",
     }
 
+    fakes.md5.withArgs("INBOX").returns("md5-value");
     fakes.apn.client.write = sinon.stub().returns({});
 
     const Controller = require("../lib/controller")({
@@ -39,32 +40,97 @@ describe("Controller", function() {
   });
 
   describe("notify", function() {
-    it("pushes to each registered device token", function () {
-      const notify = controller.notify("test@example.com", "INBOX");
-      fakes.redis.smembers.yield(null, ["123456abcdef:account-id-1234", "4567890fedcba:account-id-4567"]);
+    let notify;
+    describe("push behaviour", function () {
 
       const expectedNotification = function (accountId) {
-        const expectedBody = JSON.stringify({"aps": { "account-id": accountId}});
+        const expectedBody = JSON.stringify({"aps": { "account-id": accountId, m: [ "md5-value" ]}});
         return sinon.match(function (value) {
           return value.body == expectedBody;
         }, expectedBody);
       };
 
-      return notify.then( () => {
-        expect(fakes.apn.client.write).to.have.been.calledWith(expectedNotification("account-id-1234"), "123456abcdef");
-        expect(fakes.apn.client.write).to.have.been.calledWith(expectedNotification("account-id-4567"), "4567890fedcba");
+      beforeEach(function () {
+        notify = controller.notify("test@example.com", "INBOX");
+        
+        fakes.redis.sismember.withArgs("test_pn_prefix:test@example.com:123456abcdef:account-id-1234:subscriptions", "md5-value").yields(null, 1);
+        fakes.redis.sismember.withArgs("test_pn_prefix:test@example.com:123456abcdef:account-id-4567:subscriptions", "md5-value").yields(null, 0);
+        fakes.redis.sismember.withArgs("test_pn_prefix:test@example.com:4567890fedcba:account-id-4567:subscriptions", "md5-value").yields(null, 1);
+
+        fakes.redis.smembers.yield(null, [
+          "123456abcdef:account-id-1234", 
+          "123456abcdef:account-id-4567",
+          "4567890fedcba:account-id-4567",
+        ]);
+      });
+
+      it("pushes to each registered and subscribed device token", function () {
+        return notify.then( () => {
+          expect(fakes.apn.client.write).to.have.been.calledWith(expectedNotification("account-id-1234"), "123456abcdef");
+          expect(fakes.apn.client.write).to.have.been.calledWith(expectedNotification("account-id-4567"), "4567890fedcba");
+        });
+      });
+
+      it("does not push to non-subscribed device token", function () {
+        return notify.then( () => {
+          expect(fakes.apn.client.write).to.have.not.been.calledWith(expectedNotification("account-id-4567"), "123456abcdef");
+        });
       });
     });
 
-    it("cleans up failed device tokens", function () {
-      fakes.apn.client.write.withArgs(sinon.match.any, "123456abcdef").returns( { status: 410, device: "123456abcdef", response: { reason: "Unregistered", timestamp: 0 } });
-      fakes.redis.srem.yields(null, 1);
+    context("token rejected", function () {
+      let apnWriteResolve;
+      beforeEach(function () {
+        fakes.apn.client.write.withArgs(sinon.match.any, "123456abcdef")
+          .returns(new Promise( resolve => { apnWriteResolve = resolve; }));
 
-      const notify = controller.notify("test@example.com", "INBOX");
-      fakes.redis.smembers.yield(null, ["123456abcdef:account-id-1234", "4567890fedcba:account-id-4567"]);
+        fakes.redis.srem.yields(null, 1);
+        fakes.redis.del.yields(null, 1);
 
-      return notify.then( () => {
-        expect(fakes.redis.srem).to.be.calledWith("test_pn_prefix:test@example.com:device", "123456abcdef:account-id-1234");
+        fakes.redis.sismember.withArgs("test_pn_prefix:test@example.com:123456abcdef:account-id-1234:subscriptions", "md5-value").yields(null, 1);
+        fakes.redis.sismember.withArgs("test_pn_prefix:test@example.com:4567890fedcba:account-id-4567:subscriptions", "md5-value").yields(null, 1);
+
+        notify = controller.notify("test@example.com", "INBOX");
+        
+        fakes.redis.smembers.yield(null, ["123456abcdef:account-id-1234", "4567890fedcba:account-id-4567"]);
+      });
+
+      context("`Unregistered` token", function () {
+        beforeEach(function () {
+          apnWriteResolve({ status: "410", device: "123456abcdef", response: { reason: "Unregistered", timestamp: 0 } });
+        });
+        
+        it("cleans up failed device token from user account", function () {
+          return notify.then( () => {
+            expect(fakes.redis.srem).to.be.calledOnce;
+            expect(fakes.redis.srem).to.be.calledWith("test_pn_prefix:test@example.com:device", "123456abcdef:account-id-1234");
+          });
+        });
+
+        it("deletes device subscriptions set", function (){
+          return notify.then( () => {
+            expect(fakes.redis.del).to.be.calledOnce;
+            expect(fakes.redis.del).to.be.calledWith("test_pn_prefix:test@example.com:123456abcdef:account-id-1234:subscriptions");
+          });
+        });
+      });
+
+      context("other reason", function () {
+        beforeEach(function () {
+          apnWriteResolve({ status: "503", device: "123456abcdef", response: { reason: "ServiceUnavailable" } });
+        });
+
+        it("does not cleanup the token from the user account", function () {
+          return notify.then( () => {
+            expect(fakes.redis.srem).to.not.be.called;
+          });
+        });
+
+        it("does not delete the device subscriptions set", function (){
+          return notify.then( () => {
+            expect(fakes.redis.del).to.not.be.called;
+          });
+        });
       });
     });
   });

--- a/test/server.js
+++ b/test/server.js
@@ -41,6 +41,21 @@ describe("server", function() {
     server.receive(message);
     expect(fakes.controller.notify).to.be.calledWith("test@example.com", "INBOX");
   });
+
+  it("handles subscription messages", function() {
+    let message = encodeMsgData({
+      type: 4,
+      pid: 0,
+
+      d1: "test@example.com",      // Username
+      d2: "account-id-1234",       // Account ID
+      d3: "1234567890abcdef",      // Device Token
+      d4: "INBOX",                 // Mailbox
+    });
+
+    server.receive(message);
+    expect(fakes.controller.subscribe).to.be.calledWith("test@example.com", "account-id-1234", "1234567890abcdef", "INBOX");
+  });
 });
 
 function encodeMsgData(data) {

--- a/test/support.js
+++ b/test/support.js
@@ -23,15 +23,19 @@ function RedisClient() {
   this.sadd      = sinon.stub();
   this.srem      = sinon.stub();
   this.smembers  = sinon.stub();
+  this.sismember = sinon.stub();
   this.set       = sinon.stub();
   this.get       = sinon.stub();
+  this.del       = sinon.stub();
 }
 
-RedisClient.prototype.sadd     = function () {};
-RedisClient.prototype.srem     = function () {};
-RedisClient.prototype.smembers = function () {};
-RedisClient.prototype.set      = function () {};
-RedisClient.prototype.get      = function () {};
+RedisClient.prototype.sadd      = function () {};
+RedisClient.prototype.srem      = function () {};
+RedisClient.prototype.smembers  = function () {};
+RedisClient.prototype.sismember = function () {};
+RedisClient.prototype.set       = function () {};
+RedisClient.prototype.get       = function () {};
+RedisClient.prototype.del       = function () {};
 
 Promise.promisifyAll(RedisClient.prototype);
 


### PR DESCRIPTION
iOS Mail.app supports selective mailbox subscriptions for push.
- Subscriptions are re-registered whenever the client re-registers the device token
  - Clear subscriptions when device registration occurs to be immediately followed by subscription messages
- Notification should only be sent when the mailbox affected is in the subscription list
- The MD5'd name of the affected mailbox should be included in the notification as `m: md5(mailbox_name)` alongside the account id
- Subscriptions are `username : account id : device id` specific
